### PR TITLE
Activate the plugin on any ini file

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -6,12 +6,12 @@ const foldingRangeProvider_1 = require("./foldingRangeProvider.js")
 
 function activate(context) {
     context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider([
-        { language: 'ini', pattern: '**/*.{ini,cfg,reg}' },
+        { language: 'ini' },
         { language: 'ini', scheme: 'untitled' },
     ], new documentSymbolProvider_1.IniDocumentSymbolProvider()));
 
     context.subscriptions.push(vscode.languages.registerFoldingRangeProvider([
-        { language: 'ini', pattern: '**/*.{ini,cfg,reg}' },
+        { language: 'ini' },
         { language: 'ini', scheme: 'untitled' },
     ], new foldingRangeProvider_1.IniFoldingRangeProvider()));
 }


### PR DESCRIPTION
The plugin only works properly for ´.ini´, ´.cfg´ and ´.reg´ files.
With these changes it will work for any file being opened with language mode = 'ini' (regardless its file extension).