### PR TITLE
Added comment token # to RegEx

### DIFF
--- a/src/docSymbolProvider.js
+++ b/src/docSymbolProvider.js
@@ -8,7 +8,7 @@ class IniDocumentSymbolProvider {
         // 段
         const sectionRegex = /^\s*\[([^\]]+)\]/;
         // 键
-        const keyRegex = /^\s*([^\[;=]+)\s*=/;
+        const keyRegex = /^\s*([^\[#;=]+)\s*=/;
 
         let prevSecName = null;
         let prevSecRangeStart = null;

--- a/src/foldingRangeProvider.js
+++ b/src/foldingRangeProvider.js
@@ -8,7 +8,7 @@ class IniFoldingRangeProvider {
         // 段
         const sectionRegex = /^\s*\[([^\]]+)\]/;
         // 键
-        const keyRegex = /^\s*([^\[;=]+)\s*=/;
+        const keyRegex = /^\s*([^\[#;=]+)\s*=/;
 
         // 支持嵌套的region语法：;region 和 ;endregion
         const regionStartRegex = /^\s*\;+\s*region/i;


### PR DESCRIPTION
added # so that commented suggestions of the key will not be displayed in the outline e.g.

```
[area1]
# value = 1 does this
# value = 2 does that
value = 1
```

will no longer include commented lines in the outline